### PR TITLE
fix precision of `np.datetime64()` to avoid warnings

### DIFF
--- a/safe_s1/sentinel1_xml_mappings.py
+++ b/safe_s1/sentinel1_xml_mappings.py
@@ -30,7 +30,7 @@ scalar = lambda x: x[0]
 scalar_int = lambda x: int(x[0])
 scalar_float = lambda x: float(x[0])
 date_converter = lambda x: datetime.strptime(x[0], '%Y-%m-%dT%H:%M:%S.%f')
-datetime64_array = lambda x: np.array([np.datetime64(date_converter([sx])) for sx in x])
+datetime64_array = lambda x: np.array([np.datetime64(date_converter([sx])).astype("datetime64[ns]") for sx in x])
 int_1Darray_from_string = lambda x: np.fromstring(x[0], dtype=int, sep=' ')
 float_2Darray_from_string_list = lambda x: np.vstack([np.fromstring(e, dtype=float, sep=' ') for e in x])
 list_of_float_1D_array_from_string = lambda x: [np.fromstring(e, dtype=float, sep=' ') for e in x]


### PR DESCRIPTION
Lots of warnings are issued because of update in numpy:
```python
xarray-safe-s1/safe_s1/sentinel1_xml_mappings.py:706: UserWarning: Converting non-nanosecond precision datetime values to nanosecond precision. This behavior can eventually be relaxed in xarray, as it is an artifact from pandas which is now beginning to support non-nanosecond precision values. This warning is caused by passing non-nanosecond np.datetime64 or np.timedelta64 values to the DataArray or Variable constructor; it can be silenced by converting the values to nanosecond precision ahead of time.
  return xr.DataArray(values, dims=['line', 'sample'], coords={'line': line, 'sample': sample})
  ```
  This PR fixes this.