### PR TITLE
integrate a patch on noise range coordinates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ __pycache__/
 .coverage.*
 .cache
 /docs/_build/
+
+localconfig.yml
+highleveltests


### PR DESCRIPTION
Level-1 SLC products have an issue with the coordinates 'line' values: see https://jira-projects.cls.fr/browse/MPCS-3581
![image](https://github.com/umr-lops/xarray-safe-s1/assets/14925067/29ba0e70-d20f-4ce7-bad2-1a19745dd064)

@lanougue proposed this patch:
```python
def corrected_range_noise_lut(dt):
    """
    Return range noise lut with corrected line numbering. This function should be used only on the full SLC dataset dt
    Args:
        dt (xarray.datatree) : datatree returned by xsar corresponding to one subswath
    Return:
        (xarray.dataset) : range noise lut with corrected line number
    """
    # Detection of azimuthTime jumps (linked to burst changes). Burst sensingTime should NOT be used since they have erroneous value too !
    tt = dt['measurement']['time']
    i_jump = np.ravel(np.argwhere(np.diff(tt)<np.timedelta64(0))+1) # index of jumps
    line_jump_meas = dt['measurement']['line'][i_jump] # line number of jumps
    line_jump_noise = np.ravel(dt['noise_range']['line'][1:-1].data) # annoted line number of burst begining
    burst_first_lineshift = line_jump_meas-line_jump_noise
    if len(np.unique(burst_first_lineshift))==1:
        line_shift = int(np.unique(burst_first_lineshift)[0])
    else:
        raise ValueError('Inconsistency in line shifting : {}'.format(burst_first_lineshift))

    return dt['noise_range'].ds.assign_coords({'line':dt['noise_range']['line']+line_shift})
``` 
in this patch the `line` and `time` coordinates are coming from the high resolution return by the method https://github.com/umr-lops/xarray-safe-s1/blob/5a99c192c5ed871eb3d31b3a8967a820d1e4242a/safe_s1/metadata.py#L109.


Best option for now is: to make the `load_digital_number` method called systematically in `xarray-safe-s1` reader (and not in `xsar` )

