### PR TITLE
 fix issue 52 (numpy index/str casting issue)

### DIFF
--- a/safe_s1/reader.py
+++ b/safe_s1/reader.py
@@ -668,7 +668,7 @@ class Sentinel1Reader:
             pol = os.path.basename(xml_file).split("-")[4].upper()
             pols.append(pol)
             tmp.append(luts_ds)
-        ds = xr.concat(tmp, pd.Index(pols, name="pol"))
+        ds = xr.concat(tmp, pd.Index(pols, name="pol").astype(np.str_))
         # ds.attrs = {'description':
         #                                 'original (ie not interpolation) xr.Dataset sigma0 and gamma0 Look Up Tables'}
         return ds


### PR DESCRIPTION
this PR aims at fixing #52 
tested with `numpy==2.3.3`
- [x] unit test: ok
- [x] high level tests: ok
- [x] `xsar` test: ok
- [x] doc sphinx: ok
- [x] fix `dtype` of polarization in the `xarray.Dataset`

dont know how to trigger the `upstream-dev` on this particular branch, but the tests passed are somehow equivalent.